### PR TITLE
add spinner waiting for frontend service to be ready

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,5 +24,3 @@ services:
       - "/dev/fb0:/dev/fb0"
       - "/dev/fb1:/dev/fb1"
       - "/dev/vchiq:/dev/vchiq"
-    environment:
-      WPE_URL: http://proxy/

--- a/wpe/Dockerfile
+++ b/wpe/Dockerfile
@@ -1,5 +1,10 @@
-FROM petrosagg/resin-wpe:raspberrypi3-9416a43
+FROM petrosagg/resin-wpe:raspberrypi3-42bbb24
 
 COPY wpe-init /wpe-init
 
+COPY public_html /var/lib/public_html
+
+ENV WPE_URL="file:///var/lib/public_html/index.html"
+
 CMD [ "/wpe-init" ]
+

--- a/wpe/public_html/index.html
+++ b/wpe/public_html/index.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="http://code.jquery.com/jquery-1.11.0.min.js"></script>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>JS Bin</title>
+  <link rel="stylesheet" href="styles.css">
+  <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet">
+</head>
+<body>
+  <div id="container">
+      <a id="update" href="#">
+          <i id="loader" class="fa fa-cog fa-spin fa-5x fa-fw"></i>
+      </a>
+  </div>
+
+  <script>
+        function status(response) {
+          console.log(response)
+          if (response.ok) {
+            return response
+          } 
+          console.log(response.statusText)
+          throw new Error(response.statusText)
+        }
+        
+        setInterval(() => {
+          fetch('http://proxy/')
+          .then(status)
+          .then(function(data) {
+            console.log('fetch success');
+            $('#loader').hide();
+            window.location = 'http://proxy/'
+          }).catch(function(error) {
+            console.log('Request failed', error);
+          });
+        }, 1000);
+  </script>
+</body>
+</html>

--- a/wpe/public_html/styles.css
+++ b/wpe/public_html/styles.css
@@ -1,0 +1,17 @@
+#container {
+    display: table;
+    position: absolute;
+    top: 50%;
+    left: 42%;
+    transform: translateY(-50%);
+}
+
+#update {
+    display: table-cell;
+    vertical-align: middle;
+    text-align: center;
+}
+
+#loader {
+    color: black;
+}


### PR DESCRIPTION
This PR just adds a simple spinner that waits for the frontend service to be ready before redirecting to it. This fixes a race condition which happened when the device was rebooted and all the services started simulatenously, which resulted in the GUI requesting from the `frontend` service before it was ready to serve.