### PR TITLE
Add logic to change graph color

### DIFF
--- a/data/index.js
+++ b/data/index.js
@@ -10,6 +10,11 @@ period = parseInt(process.env.PERIOD) || 500;
 
 server.listen(8080);
 
+let sendTemp = function(socket, data) {
+  // data.color = '#FF0000'
+  socket.emit('temperature', data);
+}
+
 let getCpuTemp = function(socket) {
   'use strict';
   exec('cat /sys/class/thermal/thermal_zone*/temp', (err, stdout) => {
@@ -17,7 +22,7 @@ let getCpuTemp = function(socket) {
     let data = {
       t: parseFloat(stdout) / 1000
     };
-    socket.emit('temperature', data);
+    sendTemp(socket, data);
   });
 };
 
@@ -26,7 +31,7 @@ let getRandomTemp = function(socket) {
   let data = {
     t: (20 + Math.floor(Math.random() * 30))
   };
-  socket.emit('temperature', data);
+  sendTemp(socket, data);
 };
 
 io.on('connection', function(socket) {

--- a/frontend/static/js/main.js
+++ b/frontend/static/js/main.js
@@ -51,6 +51,10 @@ define(["jquery", "highcharts", "socketio"], function($, Highcharts, io) {
 
     socket.on("temperature", function(data) {
       var series = chart.series[0];
+
+      // If data.color is undefined, Highcharts fall back to the default color (blue)
+      chart.series[0].options.color = data.color;
+      chart.series[0].update(chart.series[0].options);
       series.addPoint([data.t], true, series.data.length > 200);
     });
   });

--- a/wpe/public_html/index.html
+++ b/wpe/public_html/index.html
@@ -15,6 +15,7 @@
         throw new Error(response.statusText)
     }
 
+    var reload = false;
     $(document).ready(function() {
         setInterval(() => {
           fetch('http://proxy/')
@@ -23,8 +24,14 @@
             console.log('fetch success');
             $('#loader').hide();
             window.location = 'http://proxy/'
+            if (reload) {
+              reload = false
+              window.location.reload(true)
+            }
+
           }).catch(function(error) {
             console.log('Request failed', error);
+            reload = true
           });
         }, 1000);
     })


### PR DESCRIPTION
The demo script here is to:

- Uncomment `// data.color = '#FF0000'` at `data/index.js`:14. This will change the color of the graph from the default blue to red. Some additinal logic was added to the `wpe` service (`wpe/public_html/index.html`) to reload the page after a `fetch` failure.
- Uncomment `getCpuTemp(socket);` and comment out `getRandTemp(socket)` at `data/index.js`, to get the real temperature readings.

The motivation of the color change functionality is to show a visible change in the remote Beast tiles after the update has succeeded